### PR TITLE
Fix String.split_at can not split "\r\n",issue #19

### DIFF
--- a/lib/neotomex/grammar.ex
+++ b/lib/neotomex/grammar.ex
@@ -327,6 +327,11 @@ defmodule Neotomex.Grammar do
         end
       nil ->
         :mismatch
+      ["\r"] ->
+        # String.split_at can't split "\r\n"  into  {"\r","\n"}
+        # Using Regex.split to replace it.
+        ["", rest] = Regex.split(~r/^\r/, input)
+        {:ok, {expr_trans, "\r"}, rest}
       [match] ->
         # Two parts are necessary since the first is being trimmed away
         {^match, rest} = String.split_at(input, String.length(match))


### PR DESCRIPTION
Add  **["\r"] -> match branch** using Regex.split  to split "\r\n"，can reduce frequency of Regex.split function call.