### PR TITLE
Fix inconsistency of message field in exception modules

### DIFF
--- a/lib/neotomex/grammar.ex
+++ b/lib/neotomex/grammar.ex
@@ -103,10 +103,10 @@ defmodule Neotomex.Grammar do
     @moduledoc """
     Exception raised on parse errors.
     """
-    defexception [error: nil, description: "parse error"]
+    defexception [error: nil, message: "parse error"]
 
     def message(exception) do
-      exception.description
+      exception.message
     end
   end
 
@@ -115,10 +115,10 @@ defmodule Neotomex.Grammar do
     @moduledoc """
     Exception raised on validation errors.
     """
-    defexception [error: nil, description: "validation error"]
+    defexception [error: nil, message: "validation error"]
 
     def message(exception) do
-      exception.description <> ": " <> error_to_string(exception.error)
+      exception.message <> ": " <> error_to_string(exception.error)
     end
 
     @doc false


### PR DESCRIPTION
`Neotomex.Grammar.ParseError` and `Neotomex.Grammar.ValidationError` cause warnings as below.

```
iex(1)> try do
...(1)> raise Neotomex.Grammar.ParseError, message: "parse error"
...(1)> rescue
...(1)> e in Neotomex.Grammar.ParseError -> e.description
...(1)> end
warning: the following fields are unknown when raising Neotomex.Grammar.ParseError: [message: "parse error"]. Please make sure to only give known fields when raising or redefine Neotomex.Grammar.ParseError.exception/1 to discard unknown fields. Future Elixir versions will raise on unknown fields given to raise/2
  (neotomex 0.1.7) lib/neotomex/grammar.ex:106: Neotomex.Grammar.ParseError.exception/1
  (stdlib 3.16) erl_eval.erl:685: :erl_eval.do_apply/6
  (stdlib 3.16) erl_eval.erl:893: :erl_eval.expr_list/6
  (stdlib 3.16) erl_eval.erl:408: :erl_eval.expr/5
  (stdlib 3.16) erl_eval.erl:919: :erl_eval.try_clauses/8
  (elixir 1.12.3) src/elixir.erl:280: :elixir.recur_eval/3

"parse error"
```

It is because the field names in these exceptions are inconsistent. The field name `description` in `defexception` should be `message` instead, I guess.

This fix doesn't break any tests.