### PR TITLE
Fix warnings when `mix test` is executed

### DIFF
--- a/lib/neotomex/grammar.ex
+++ b/lib/neotomex/grammar.ex
@@ -311,8 +311,6 @@ defmodule Neotomex.Grammar do
         else
           :mismatch
         end
-      {_, _} ->
-        :mismatch
     end
   end
   defp match({{:terminal, terminal}, _} = expr_trans, _, input) do
@@ -349,8 +347,8 @@ defmodule Neotomex.Grammar do
     end
   end
 
-  defp match({{:insensitive, inner}, _} = expr_trans,
-             %Neotomex.Grammar{:definitions => definitions} = grammar, input) do
+  defp match({{:insensitive, inner}, _} = _,
+             %Neotomex.Grammar{:definitions => _} = grammar, input) do
     match(inner, %{grammar | insensitive: true}, input)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Neotomex.Mixfile do
   end
 
   defp deps do
-    [{:dbg, "~> 1.0", only: :dev},
+    [{:dbg, "~> 1.0", only: [:dev, :test]},
      {:earmark, "~> 1.2", only: :dev},
      {:ex_doc, "~> 0.16", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"dbg": {:hex, :dbg, "1.0.1", "9c29813e5df8b4d275325416523d511e315656b8ac27a60519791f9cf476d83d", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}
+%{
+  "dbg": {:hex, :dbg, "1.0.1", "9c29813e5df8b4d275325416523d511e315656b8ac27a60519791f9cf476d83d", [:mix], [], "hexpm", "866159f496a1ad9b959501f16db3d1338bb6cef029a75a67ca5615d25b38345f"},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm", "59514c4a207f9f25c5252e09974367718554b6a0f41fe39f7dc232168f9cb309"},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "1d4ecdc3f292883abf88b41c69da6a81fe928d6d0d65572a64b8d63a4d707693"},
+}


### PR DESCRIPTION
`mix test` generates the warnings below:

```
$ mix test
Compiling 4 files (.ex)
warning: variable "definitions" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/neotomex/grammar.ex:353: Neotomex.Grammar.match/3

warning: variable "expr_trans" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/neotomex/grammar.ex:352: Neotomex.Grammar.match/3

warning: this clause cannot match because a previous clause at line 308 always matches
  lib/neotomex/grammar.ex:314

warning: Dbg.clear/0 is undefined (module Dbg is not available or is yet to be defined)
  lib/neotomex.ex:34: Neotomex.clear_trace/0

warning: Dbg.local_call/1 is undefined (module Dbg is not available or is yet to be defined)
  lib/neotomex.ex:25: Neotomex.trace/0

warning: Dbg.trace/2 is undefined (module Dbg is not available or is yet to be defined)
  lib/neotomex.ex:23: Neotomex.trace/0

Generated neotomex app
..............................

Finished in 0.2 seconds (0.00s async, 0.2s sync)
3 doctests, 27 tests, 0 failures

Randomized with seed 752248
```

To suppress these warnings, I fix the code along with these warnings messages, in addition to updating dependencies.

This fix doesn't break any tests.